### PR TITLE
Create custom db user

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -34,6 +34,12 @@
 			]	
 		}
 	},
+	"containerEnv": {
+		"POSTGRES_PASSWORD": "${localEnv:PG_PASS}",
+		"POSTGRES_USER": "${localEnv:PG_USER}",
+		"POSTGRES_DB": "${localEnv:PG_DB}",
+		"POSTGRES_DB_URI": "${localEnv:PG_DB_URI}"
+	},
 	//"postCreateCommand": "",
 
 	// Use 'forwardPorts' to make a list of ports inside the container available locally.

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -34,12 +34,6 @@
 			]	
 		}
 	},
-	"containerEnv": {
-		"POSTGRES_PASSWORD": "${localEnv:PG_PASS}",
-		"POSTGRES_USER": "${localEnv:PG_USER}",
-		"POSTGRES_DB": "${localEnv:PG_DB}",
-		"POSTGRES_DB_URI": "${localEnv:PG_DB_URI}"
-	},
 	//"postCreateCommand": "",
 
 	// Use 'forwardPorts' to make a list of ports inside the container available locally.

--- a/.devcontainer/docker-compose.yml
+++ b/.devcontainer/docker-compose.yml
@@ -16,7 +16,7 @@ services:
       FLASK_APP: service:app
       FLASK_DEBUG: "True"
       PORT: 8000
-      DATABASE_URI: postgresql://postgres:postgres@postgres:5432/postgres
+      DATABASE_URI: ${PG_DB_URI}
     networks:
       - dev
     depends_on:
@@ -29,7 +29,9 @@ services:
     # ports:
     #   - 5432:5432
     environment:
-      POSTGRES_PASSWORD: postgres
+      POSTGRES_PASSWORD: ${PG_PASS}
+      POSTGRES_USER: ${PG_USER}
+      POSTGRES_DB: ${PG_DB}
     volumes:
       - postgres:/var/lib/postgresql/data
     networks:

--- a/.gitignore
+++ b/.gitignore
@@ -102,3 +102,6 @@ ENV/
 
 # Rope project settings
 .ropeproject
+
+# Project Shopcarts
+.devcontainer/.env

--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ tests/              - test cases package
 1. Leveraging the Docker command to launch the PostgreSQL CLI in the shopcarts.db container using the following command:
 
     ```bash
-    docker exec -it shopcarts.db psql -U postgres -d postgres -h localhost -p 5432
+    docker exec -it shopcarts.db psql -U shopcarts_app -d shopcarts -h localhost -p 5432
     ```
 
 ## License


### PR DESCRIPTION
## Goal
1. Create custom DB user `shopcarts_app` (rather than the default user `postgres`)
2. Create custom DB database `shopcarts` (rather than the default database `postgres`)
3. Ignore `.devcontiner/.env` by default

### Notes
1. Assumed each developer would manually stop the app containers and delete the shopcarts database volume in docker (e.g. `docker volume rm shopcarts_devcontainer_postgres`) before adopting this change
2. Assumed each developer would manually create the env file (e.g. `.devcontainer/.env`) with the following key-value pairs
    ```bash
    PG_PASS="${TO_BE_GIVEN}"
    PG_USER="shopcarts_app"
    PG_DB="shopcarts"
    PG_DB_URI="postgresql://shopcarts_app:${TO_BE_GIVEN}@postgres:5432/shopcarts"
    ```