### PR TITLE
Implement Add Shopcart Item API logic

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,6 +78,64 @@ delete_items      DELETE   /shopcarts/<shopcart_id>/items/<item_id>
 
 The test cases can be run with `green`.
 
+### Create Shopcart Item
+Add a new item to shopcart.
+
+#### API Endpoint
+POST /shopcarts/<shopcart_id>/items
+
+#### Request Headers
+| Header       | Value            |
+|--------------|------------------|
+| Content-Type | application/json |
+
+#### Request Body
+```json
+{
+  "name": "iPhone SE",
+  "price": 500.0,
+  "quantity": 1
+}
+```
+
+#### Response
+##### 200 OK
+```json
+{
+  "id": 1,
+  "name": "iPhone SE",
+  "price": 500.0,
+  "quantity": 1,
+  "shopcart_id": 1
+}
+```
+
+##### 400 Bad Request
+```json
+{
+  "error": "Bad Request",
+  "message": "Quantity of a new item should always be one.",
+  "status": 400
+}
+```
+
+##### 404 Not Found
+```json
+{
+  "error": "Not Found",
+  "message": "Shopcart with id='3' was not found.",
+  "status": 404
+}
+```
+
+##### 500 Internal Server Error
+```json
+{
+  "error": "Internal Server Error",
+  "message": "${error_message}",
+  "status": 500
+}
+```
 
 ## Database Connection
 

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# NYU DevOps Project: The Shopcarts Service
+# The Shopcarts Service
 
 [![License](https://img.shields.io/badge/License-Apache_2.0-blue.svg)](https://opensource.org/licenses/Apache-2.0)
 [![Python](https://img.shields.io/badge/Language-Python-blue.svg)](https://python.org/)
@@ -54,6 +54,30 @@ tests/              - test cases package
 ├── test_models.py  - test suite for business models
 └── test_routes.py  - test suite for service routes
 ```
+
+## RESTful routes
+
+These are the RESTful routes for `shopcarts` and `items`
+```markdown
+Endpoint          Methods  Rule
+----------------  -------  -----------------------------------------------------
+index             GET      /
+
+list_shopcarts    GET      /shopcarts
+create_shopcarts  POST     /shopcarts
+get_shopcarts     GET      /shopcarts/<shopcart_id>
+update_shopcarts  PUT      /shopcarts/<shopcart_id>
+delete_shopcarts  DELETE   /shopcarts/<shopcart_id>
+
+list_items        GET      /shopcarts/<shopcart_id>/items
+create_items      POST     /shopcarts/<shopcart_id>/items
+get_items         GET      /shopcarts/<shopcart_id>/items/<item_id>
+update_items      PUT      /shopcarts/<shopcart_id>/items/<item_id>
+delete_items      DELETE   /shopcarts/<shopcart_id>/items/<item_id>
+```
+
+The test cases can be run with `green`.
+
 
 ## Database Connection
 

--- a/service/models.py
+++ b/service/models.py
@@ -120,7 +120,7 @@ class Shopcart(db.Model, ModelBase):
         try:
             # self.id = data["id"]
             self.name = data["name"]
-            items_js = data["items"]
+            items_js = data.get("items", [])
             for item_js in items_js:
                 item = Item()
                 item.deserialize(item_js)

--- a/service/routes.py
+++ b/service/routes.py
@@ -113,10 +113,13 @@ def add_shopcart_item(shopcart_id):
     except DataValidationError as e:
         return request_validation_error(e)
 
-    # item quantity should be greater than zero
-    if item.quantity <= 0:
+    # # item quantity should be greater than zero
+    # if item.quantity <= 0:
+    #     app.logger.error(f"Invalid item quantity assignment to {item.quantity}.")
+    #     return bad_request(f"Item quantity should be a positive number.")
+    if item.quantity != 1:
         app.logger.error(f"Invalid item quantity assignment to {item.quantity}.")
-        return bad_request(f"Item quantity should be a positive number.")
+        return bad_request(f"Quantity of a new item should always be one.")
 
     try:
         # item.create()

--- a/service/routes.py
+++ b/service/routes.py
@@ -105,55 +105,29 @@ def add_shopcart_item(shopcart_id):
         return not_found(f"Shopcart with id='{shopcart_id}' was not found.")
     app.logger.info(f"Found shopcart with id={shopcart.id}")
 
-    # search for the designated item in shopcart
-    request_body_js = request.get_json()
-    item = None
-    for item_ in shopcart.items:
-        if item_.id == request_body_js["id"]:
-            item = item_
-            break
-
-    # if not found, add a new item to shopcart
-    if item is None:
-        try:
-            # item quantity should be greater than zero
-            if request_body_js["quantity"] <= 0:
-                app.logger.error(f"Invalid item quantity assignment to {request_body_js['quantity']}.")
-                return bad_request(f"Invalid item quantity={request_body_js['quantity']} <= 0.")
-
-            app.logger.info(f"Start creating an item")
-            item = Item()
-            item.deserialize(request_body_js)
-            app.logger.info(f"Request body deserialized to item.")
-
-            # item.create()
-            # app.logger.info(f"New item with id={item.id} created.")
-
-            shopcart.items.append(item)
-            shopcart.update()
-            app.logger.info(f"New item with id={item.id} added to shopcart with id={shopcart.id}.")
-
-            item_js = item.serialize()
-            return make_response(jsonify(item_js), status.HTTP_201_CREATED)
-        except DataValidationError as e:
-            return request_validation_error(e)
-        except Exception as e:
-            return internal_server_error(e)
-
-    # otherwise, update its quantity
     try:
-        # item quantity can only increase in add_shopcart_item API
-        if item.quantity >= request_body_js["quantity"]:
-            app.logger.error(f"Invalid item quantity change from {item.quantity} to {request_body_js['quantity']}.")
-            return bad_request(f"Item quantity can not decrease. Must increase at least by one.")
+        app.logger.info(f"Start creating an item")
+        item = Item()
+        item.deserialize(request.get_json())   # validate request body schema
+        app.logger.info(f"Request body deserialized to item.")
+    except DataValidationError as e:
+        return request_validation_error(e)
 
-        item.quantity = request_body_js["quantity"]
-        item.update()
-        app.logger.info(f"Quantity updated to {item.quantity} for the existing item with id={item.id}.")
+    # item quantity should be greater than zero
+    if item.quantity <= 0:
+        app.logger.error(f"Invalid item quantity assignment to {item.quantity}.")
+        return bad_request(f"Item quantity should be a positive number.")
+
+    try:
+        # item.create()
+        # app.logger.info(f"New item with id={item.id} created.")
+        shopcart.items.append(item)
+        shopcart.update()
+        app.logger.info(f"New item with id={item.id} added to shopcart with id={shopcart.id}.")
 
         item_js = item.serialize()
-        return make_response(jsonify(item_js), status.HTTP_200_OK)
-    except KeyError as e:
+        return make_response(jsonify(item_js), status.HTTP_201_CREATED)
+    except DataValidationError as e:
         return request_validation_error(e)
     except Exception as e:
         return internal_server_error(e)

--- a/service/routes.py
+++ b/service/routes.py
@@ -89,3 +89,71 @@ def create_shopcart():
 ######################################################################
 # I T E M   A P I S
 ######################################################################
+
+@app.route("/shopcarts/<int:shopcart_id>/items", methods=["POST"])
+def add_shopcart_item(shopcart_id):
+    """ Adds a new item to shopcart, and return the newly created or updated item """
+    if not is_expected_content_type(DEFAULT_CONTENT_TYPE):
+        return mediatype_not_supported(f"Content-Type must be {DEFAULT_CONTENT_TYPE}")
+
+    try:
+        shopcart = Shopcart.get_by_id(shopcart_id)
+    except Exception as e:
+        return internal_server_error(e)
+
+    if not shopcart:
+        return not_found(f"Shopcart with id='{shopcart_id}' was not found.")
+    app.logger.info(f"Found shopcart with id={shopcart.id}")
+
+    # search for the designated item in shopcart
+    request_body_js = request.get_json()
+    item = None
+    for item_ in shopcart.items:
+        if item_.id == request_body_js["id"]:
+            item = item_
+            break
+
+    # if not found, add a new item to shopcart
+    if item is None:
+        try:
+            # item quantity should be greater than zero
+            if request_body_js["quantity"] <= 0:
+                app.logger.error(f"Invalid item quantity assignment to {request_body_js['quantity']}.")
+                return bad_request(f"Invalid item quantity={request_body_js['quantity']} <= 0.")
+
+            app.logger.info(f"Start creating an item")
+            item = Item()
+            item.deserialize(request_body_js)
+            app.logger.info(f"Request body deserialized to item.")
+
+            # item.create()
+            # app.logger.info(f"New item with id={item.id} created.")
+
+            shopcart.items.append(item)
+            shopcart.update()
+            app.logger.info(f"New item with id={item.id} added to shopcart with id={shopcart.id}.")
+
+            item_js = item.serialize()
+            return make_response(jsonify(item_js), status.HTTP_201_CREATED)
+        except DataValidationError as e:
+            return request_validation_error(e)
+        except Exception as e:
+            return internal_server_error(e)
+
+    # otherwise, update its quantity
+    try:
+        # item quantity can only increase in add_shopcart_item API
+        if item.quantity >= request_body_js["quantity"]:
+            app.logger.error(f"Invalid item quantity change from {item.quantity} to {request_body_js['quantity']}.")
+            return bad_request(f"Item quantity can not decrease. Must increase at least by one.")
+
+        item.quantity = request_body_js["quantity"]
+        item.update()
+        app.logger.info(f"Quantity updated to {item.quantity} for the existing item with id={item.id}.")
+
+        item_js = item.serialize()
+        return make_response(jsonify(item_js), status.HTTP_200_OK)
+    except KeyError as e:
+        return request_validation_error(e)
+    except Exception as e:
+        return internal_server_error(e)


### PR DESCRIPTION
Shopcart Item CRUD related tests require the Add Shopcart Item API to be ready in `route.py`, hence I implemented the logic first, and added documentations to README as well. Test cases in `test_route.py` and `models.py` are yet to be added.

![add-a-shopcart-item](https://github.com/CSCI-GA-2820-SU23-001/shopcarts/assets/117547590/80896d78-6171-4a57-a2c4-25ba0ad126b9)