### PR TITLE
List Shopcart Items API

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,6 +78,51 @@ delete_items      DELETE   /shopcarts/<shopcart_id>/items/<item_id>
 
 The test cases can be run with `green`.
 
+
+### List Shopcart Items
+Get a list of items in the shopcart.
+
+#### API Endpoint
+GET /shopcarts/{shopcart_id}/items
+
+#### Request Headers
+| Header       | Value            |
+|--------------|------------------|
+| Content-Type | application/json |
+
+#### Response
+##### 200 OK
+```json
+[
+  {
+    "id": 2,
+    "name": "iPhone SE",
+    "price": 500.0,
+    "quantity": 1,
+    "shopcart_id": 3
+  }
+]
+```
+
+##### 400 Bad Request
+```json
+{
+  "error": "Not Found",
+  "message": "Shopcart with id='0' was not found.",
+  "status": 404
+}
+```
+
+##### 500 Internal Server Error
+```json
+{
+  "error": "Internal Server Error",
+  "message": "${error_message}",
+  "status": 500
+}
+```
+
+
 ### Create Shopcart Item
 Add a new item to shopcart.
 

--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ tests/              - test cases package
 └── test_routes.py  - test suite for service routes
 ```
 
-## RESTful routes
+## RESTful Routes
 
 These are the RESTful routes for `shopcarts` and `items`
 ```markdown

--- a/service/routes.py
+++ b/service/routes.py
@@ -157,3 +157,24 @@ def add_shopcart_item(shopcart_id):
         return request_validation_error(e)
     except Exception as e:
         return internal_server_error(e)
+
+
+@app.route("/shopcarts/<int:shopcart_id>/items", methods=["GET"])
+def list_shopcart_items(shopcart_id):
+    """ Returns a list of items in the shopcart """
+    app.logger.info(f"Get items in the shopcart with id={shopcart_id}")
+
+    try:
+        shopcart = Shopcart.get_by_id(shopcart_id)
+    except Exception as e:
+        return internal_server_error(e)
+
+    if not shopcart:
+        return not_found(f"Shopcart with id='{shopcart_id}' was not found.")
+    app.logger.info(f"Found shopcart with id={shopcart.id}")
+
+    try:
+        items = [item.serialize() for item in shopcart.items]
+        return make_response(jsonify(items), status.HTTP_200_OK)
+    except Exception as e:
+        return internal_server_error(e)

--- a/tests/test_routes.py
+++ b/tests/test_routes.py
@@ -107,3 +107,9 @@ class TestShopcartsService(TestCase):
         self.assertEqual(resp.status_code, status.HTTP_200_OK)
         data = resp.get_json()
         self.assertEqual(len(data), 1)
+
+    def test_list_items_in_non_existent_shopcart(self):
+        """ It should not read a shopcart that is not found """
+        shopcart_id = -1
+        resp = self.client.get(f"{BASE_URL}/{shopcart_id}/items")
+        self.assertEqual(resp.status_code, status.HTTP_404_NOT_FOUND)

--- a/tests/test_routes.py
+++ b/tests/test_routes.py
@@ -91,3 +91,11 @@ class TestShopcartsService(TestCase):
         """ It should call the home page """
         resp = self.client.get("/")
         self.assertEqual(resp.status_code, status.HTTP_200_OK)
+
+    def test_list_empty_shopcart_items(self):
+        """ It should get an empty list of items """
+        shopcart = self._create_an_empty_shopcart(1)[0]
+        resp = self.client.get(f"{BASE_URL}/{shopcart.id}/items")
+        self.assertEqual(resp.status_code, status.HTTP_200_OK)
+        data = resp.get_json()
+        self.assertEqual(len(data), 0)

--- a/tests/test_routes.py
+++ b/tests/test_routes.py
@@ -99,3 +99,11 @@ class TestShopcartsService(TestCase):
         self.assertEqual(resp.status_code, status.HTTP_200_OK)
         data = resp.get_json()
         self.assertEqual(len(data), 0)
+
+    def test_list_shopcart_items(self):
+        """ It should get a list of only one item """
+        shopcart = self._create_a_shopcart_with_items(1)
+        resp = self.client.get(f"{BASE_URL}/{shopcart.id}/items")
+        self.assertEqual(resp.status_code, status.HTTP_200_OK)
+        data = resp.get_json()
+        self.assertEqual(len(data), 1)

--- a/tests/test_routes.py
+++ b/tests/test_routes.py
@@ -113,3 +113,9 @@ class TestShopcartsService(TestCase):
         shopcart_id = -1
         resp = self.client.get(f"{BASE_URL}/{shopcart_id}/items")
         self.assertEqual(resp.status_code, status.HTTP_404_NOT_FOUND)
+
+    @patch.object(Shopcart, 'get_by_id', MagicMock(side_effect=Exception("DBAPIErr")))
+    def test_list_shopcart_items_shopcart_get_by_id_error(self):
+        """ It should get internal server error if there's exception in Shopcart.get_by_id """
+        resp = self.client.get(f"{BASE_URL}/0/items")
+        self.assertEqual(resp.status_code, status.HTTP_500_INTERNAL_SERVER_ERROR)

--- a/tests/test_routes.py
+++ b/tests/test_routes.py
@@ -7,7 +7,7 @@ Test cases can be run with the following:
 """
 import logging
 from unittest import TestCase
-from unittest.mock import MagicMock, patch
+from unittest.mock import MagicMock, Mock, patch
 
 from service import app
 from service.common import status  # HTTP Status Codes
@@ -117,5 +117,13 @@ class TestShopcartsService(TestCase):
     @patch.object(Shopcart, 'get_by_id', MagicMock(side_effect=Exception("DBAPIErr")))
     def test_list_shopcart_items_shopcart_get_by_id_error(self):
         """ It should get internal server error if there's exception in Shopcart.get_by_id """
+        resp = self.client.get(f"{BASE_URL}/0/items")
+        self.assertEqual(resp.status_code, status.HTTP_500_INTERNAL_SERVER_ERROR)
+
+    @patch('service.models.Shopcart.get_by_id')
+    def test_list_shopcart_items_none_items_error(self, mock_shopcart_get_by_id):
+        """ It should get internal server error if Shopcart.items is None """
+        mock_shopcart = Mock(items=None)
+        mock_shopcart_get_by_id.return_value = mock_shopcart
         resp = self.client.get(f"{BASE_URL}/0/items")
         self.assertEqual(resp.status_code, status.HTTP_500_INTERNAL_SERVER_ERROR)


### PR DESCRIPTION
1. Implement List Shopcart Items API logic in `route.py`
2. Add 5 test cases to `test_route.py`, which cover all possible status code (`200`, `404`, `500`) for this API
3. Add API doc to README

### List an existing shopcart - 200 OK
![List Shopcart Items API - 200](https://github.com/CSCI-GA-2820-SU23-001/shopcarts/assets/117547590/9be7b014-2a3e-4bad-84dc-ff3530271a36)

### List a non-existent shopcart - 404 Not Found
![List Shopcart Items API - 404](https://github.com/CSCI-GA-2820-SU23-001/shopcarts/assets/117547590/9da26709-c2d0-4991-b36f-ae5b510de329)

### Test coverage goes up to 79%
![List Shopcart Items API - test coverage](https://github.com/CSCI-GA-2820-SU23-001/shopcarts/assets/117547590/97b61af4-80b6-4183-b194-522fe027aa9a)
