### PR TITLE
Set pool_recycle (maximum number of seconds a connection can persist)

### DIFF
--- a/service/config.py
+++ b/service/config.py
@@ -15,6 +15,7 @@ DATABASE_URI = os.getenv(
 # Configure SQLAlchemy
 SQLALCHEMY_DATABASE_URI = DATABASE_URI
 SQLALCHEMY_TRACK_MODIFICATIONS = False
+SQLALCHEMY_POOL_SIZE = 2
 
 # Secret for session management
 SECRET_KEY = os.getenv("SECRET_KEY", "s3cr3t-key-shhhh")

--- a/service/models.py
+++ b/service/models.py
@@ -24,7 +24,9 @@ from flask_sqlalchemy import SQLAlchemy
 logger = logging.getLogger("flask.app")
 
 # Create the SQLAlchemy object to be initialized later in init_db()
-db = SQLAlchemy()
+db = SQLAlchemy(
+    engine_options={"pool_recycle": 600}
+)
 
 
 # Function to initialize the tables in DB


### PR DESCRIPTION
# Goal
Prevent the Unit Test job from getting stuck forever in the cloud

# Changes
1. set `pool_recycle` to 600s
2. set `SQLALCHEMY_POOL_SIZE` to 2

# References
* Suggestions from the Professor: [discussion thread](https://nyu-devops-summer23.slack.com/archives/C058T4P9AUU/p1691544577597079?thread_ts=1691436667.844349&cid=C058T4P9AUU)
* [When the APIs are triggered via the frontend (e.g. BDD tests), connections are opened and remain in IDLE state.](https://stackoverflow.com/questions/72586216/how-to-reduce-idle-time-of-a-postgres-connection-using-sqlalchemy)