### PR TITLE
Refactor Create Shopcarts API

### DIFF
--- a/service/routes.py
+++ b/service/routes.py
@@ -152,6 +152,25 @@ class ShopcartCollection(Resource):
     POST /shopcarts - Create a shopcart
     """
 
+    @api.doc("create_shopcarts")
+    @api.response(400, "Invalid shopcart request body")
+    @api.response(415, "Invalid header content-type")
+    @api.expect(shopcart_base_model)
+    @api.marshal_with(shopcart_model, code=201)
+    def post(self):
+        """ Creates a new shopcart """
+        check_content_type(DEFAULT_CONTENT_TYPE)
+
+        app.logger.info("Start creating a shopcart")
+        shopcart = Shopcart()
+        shopcart.deserialize(api.payload)
+        app.logger.info("Request body deserialized to shopcart")
+
+        shopcart.create()  # store in table
+        app.logger.info("New shopcart created with id=%s", shopcart.id)
+        shopcart_js = shopcart.serialize()
+        return shopcart_js, status.HTTP_201_CREATED
+
 
 @app.route("/shopcarts", methods=["POST"])
 def create_shopcarts():

--- a/service/routes.py
+++ b/service/routes.py
@@ -22,7 +22,7 @@ PUT  /shopcarts/{shopcart_id}/items/{item_id} - Updates the item in the shopcart
 DELETE /shopcarts/{shopcart_id}/items/{item_id} - Delete the item from the shopcart
 """
 from flask import jsonify, request, make_response, abort
-from flask_restx import fields
+from flask_restx import Resource, fields
 
 from service.common import status  # HTTP Status Codes
 from service.models import Shopcart, Item
@@ -142,6 +142,16 @@ def check_content_type(expected_content_type):
 ######################################################################
 # S H O P C A R T   A P I S
 ######################################################################
+
+@api.route("/shopcarts", strict_slashes=False)
+class ShopcartCollection(Resource):
+    """
+    ShopcartCollection Class
+    Allows interactions with collections of Shopcarts:
+    GET /shopcarts - Returns a list of shopcarts
+    POST /shopcarts - Create a shopcart
+    """
+
 
 @app.route("/shopcarts", methods=["POST"])
 def create_shopcarts():

--- a/service/routes.py
+++ b/service/routes.py
@@ -63,6 +63,27 @@ item_model = api.inherit(
     },
 )
 
+shopcart_base_model = api.model(
+    "ShopcartBaseModel",
+    {
+        "name": fields.String(
+            required=True,
+            description="Customer name"
+        )
+    },
+)
+
+shopcart_model = api.inherit(
+    "ShopcartModel",
+    shopcart_base_model,
+    {
+        "id": fields.Integer(
+            readOnly=True, description="The unique id assigned internally by service"
+        ),
+        "items": fields.List(fields.Nested(item_model))
+    },
+)
+
 
 ############################################################
 # Health Endpoint

--- a/tests/test_routes.py
+++ b/tests/test_routes.py
@@ -763,7 +763,7 @@ class TestShopcartsService(BaseTestCase):
         """ It should return a 415 Unsupported media type """
         shopcart = ShopcartFactory()
         resp = self.client.post(
-            self.base_url,
+            self.base_url_restx,
             json=shopcart.serialize(),
             content_type=DEFAULT_CONTENT_TYPE)
         self.assertEqual(resp.status_code, status.HTTP_201_CREATED)
@@ -771,44 +771,44 @@ class TestShopcartsService(BaseTestCase):
     def test_create_shopcarts_with_invalid_content_type(self):
         """ It should return a 415 Unsupported media type """
         shopcart = ShopcartFactory()
-        resp = self.client.post(f"{self.base_url}",
+        resp = self.client.post(f"{self.base_url_restx}",
                                 json=shopcart.serialize(),
                                 content_type="")
         self.assertEqual(resp.status_code, status.HTTP_415_UNSUPPORTED_MEDIA_TYPE)
 
-        resp = self.client.post(f"{self.base_url}",
+        resp = self.client.post(f"{self.base_url_restx}",
                                 json=shopcart.serialize(),
                                 content_type="application/xml")
         self.assertEqual(resp.status_code, status.HTTP_415_UNSUPPORTED_MEDIA_TYPE)
 
-    def test_create_a_shopcart_with_empty_name(self):
+    def test_create_shopcarts_with_empty_name(self):
         """ It should return a 400 Bad request response when shopcart name is empty """
         shopcart = ShopcartFactory()
         shopcart.name = ""
-        resp = self.client.post(f"{self.base_url}",
+        resp = self.client.post(f"{self.base_url_restx}",
                                 json=shopcart.serialize(),
                                 content_type=DEFAULT_CONTENT_TYPE)
         self.assertEqual(resp.status_code, status.HTTP_400_BAD_REQUEST)
 
         shopcart.name = "  "
-        resp = self.client.post(f"{self.base_url}",
+        resp = self.client.post(f"{self.base_url_restx}",
                                 json=shopcart.serialize(),
                                 content_type=DEFAULT_CONTENT_TYPE)
         self.assertEqual(resp.status_code, status.HTTP_400_BAD_REQUEST)
 
-    def test_create_a_shopcart_with_null_name(self):
+    def test_create_shopcarts_with_null_name(self):
         """ It should return a 400 Bad request response when shopcart name is null """
         shopcart = ShopcartFactory()
         shopcart.name = None
-        resp = self.client.post(f"{self.base_url}",
+        resp = self.client.post(f"{self.base_url_restx}",
                                 json=shopcart.serialize(),
                                 content_type=DEFAULT_CONTENT_TYPE)
         self.assertEqual(resp.status_code, status.HTTP_400_BAD_REQUEST)
 
-    def test_create_a_shopcart_with_bad_request(self):
+    def test_create_shopcarts_with_bad_request(self):
         """It should return a 400 Bad request response"""
         shopcart = ShopcartFactory()
-        resp = self.client.post(f"{self.base_url}",
+        resp = self.client.post(f"{self.base_url_restx}",
                                 json=shopcart.serialize()['name'],
                                 content_type=DEFAULT_CONTENT_TYPE)
         self.assertEqual(resp.status_code, status.HTTP_400_BAD_REQUEST)


### PR DESCRIPTION
# Goal
Refactor Create Shopcarts API into Flask-RestX style while maintaining test coverage as before.

# Changes
1. Copy and refactor Create Shopcarts API implementation into ShopcartResource class
2. Apply base_url_restx to all Create Shopcarts API test cases

# Results

## swagger doc
![create-miffy](https://github.com/CSCI-GA-2820-SU23-001/shopcarts/assets/117547590/1be87a2c-c414-4c39-b9e5-0d47a8a212cf)

## green
![green](https://github.com/CSCI-GA-2820-SU23-001/shopcarts/assets/117547590/ec3dfeb2-ef39-4d1a-abc0-95e22d91fd2c)

## make lint
![make-lint](https://github.com/CSCI-GA-2820-SU23-001/shopcarts/assets/117547590/4ad767f0-2870-4682-b1c4-dba494de1499)

## behave
![behave](https://github.com/CSCI-GA-2820-SU23-001/shopcarts/assets/117547590/8c5680f5-5905-4ac9-bea0-a65284b20f41)
