### PR TITLE
Refactor Create Items API

### DIFF
--- a/service/routes.py
+++ b/service/routes.py
@@ -22,7 +22,7 @@ PUT  /shopcarts/{shopcart_id}/items/{item_id} - Updates the item in the shopcart
 DELETE /shopcarts/{shopcart_id}/items/{item_id} - Delete the item from the shopcart
 """
 from flask import jsonify, request, make_response, abort
-from flask_restx import fields
+from flask_restx import Resource, fields
 
 from service.common import status  # HTTP Status Codes
 from service.models import Shopcart, Item
@@ -236,6 +236,18 @@ def list_shopcarts():
 ######################################################################
 # I T E M   A P I S
 ######################################################################
+
+@api.route("/shopcarts/<int:shopcart_id>/items", strict_slashes=False)
+@api.param("shopcart_id", "The Shopcart identifier")
+class ItemCollection(Resource):
+    """
+    ItemCollection Class
+
+    Allows interactions with collections of Items:
+    POST /shopcarts/<int:shopcart_id>/items - Add an Item to shopcart
+    GET /shopcarts/<int:shopcart_id>/items - Returns a list of items in shopcart
+    """
+
 
 @app.route("/shopcarts/<int:shopcart_id>/items", methods=["POST"])
 def create_items(shopcart_id):

--- a/service/routes.py
+++ b/service/routes.py
@@ -248,6 +248,43 @@ class ItemCollection(Resource):
     GET /shopcarts/<int:shopcart_id>/items - Returns a list of items in shopcart
     """
 
+    @api.doc("create_items")
+    @api.response(400, "Invalid item request body")
+    @api.response(404, "Shopcart not found")
+    @api.response(415, "Invalid header content-type")
+    @api.expect(item_base_model)
+    @api.marshal_with(item_model, code=201)
+    def post(self, shopcart_id):
+        """ Adds a new item to shopcart, and return the newly created item """
+        check_content_type(DEFAULT_CONTENT_TYPE)
+
+        shopcart = Shopcart.get_by_id(shopcart_id)
+        if not shopcart:
+            abort(
+                status.HTTP_404_NOT_FOUND,
+                f"Shopcart with id='{shopcart_id}' was not found."
+            )
+        app.logger.info("Found shopcart with id=%s", shopcart.id)
+
+        app.logger.info("Start creating an item")
+        item = Item()
+        item.deserialize(api.payload)  # validate request body schema
+        app.logger.info("Request body deserialized to item.")
+
+        if item.quantity != 1:
+            app.logger.error("Invalid item quantity assignment to %s.", item.quantity)
+            abort(
+                status.HTTP_400_BAD_REQUEST,
+                "Quantity of a new item should always be one."
+            )
+
+        shopcart.items.append(item)
+        shopcart.update()
+        app.logger.info("New item with id=%s added to shopcart with id=%s.", item.id, shopcart.id)
+
+        item_js = item.serialize()
+        return item_js, status.HTTP_201_CREATED
+
 
 @app.route("/shopcarts/<int:shopcart_id>/items", methods=["POST"])
 def create_items(shopcart_id):

--- a/tests/test_routes.py
+++ b/tests/test_routes.py
@@ -242,7 +242,7 @@ class TestShopcartsService(BaseTestCase):
         shopcart = self._create_an_empty_shopcart(1)[0]
         item = ItemFactory()
         res = self.client.post(
-            f"{self.base_url}/{shopcart.id}/items",
+            f"{self.base_url_restx}/{shopcart.id}/items",
             json=item.serialize(),
             content_type=DEFAULT_CONTENT_TYPE,
         )
@@ -261,7 +261,7 @@ class TestShopcartsService(BaseTestCase):
         item = ItemFactory(shopcart_id=test_id)
         self.assertNotEqual(test_id, shopcart.id)
         resp = self.client.post(
-            f"{self.base_url}/{test_id}/items",
+            f"{self.base_url_restx}/{test_id}/items",
             json=item.serialize(),
             content_type=DEFAULT_CONTENT_TYPE,
         )
@@ -271,7 +271,7 @@ class TestShopcartsService(BaseTestCase):
         """ It should not be added with invalid request body """
         shopcart = self._create_an_empty_shopcart(1)[0]
         res = self.client.post(
-            f"{self.base_url}/{shopcart.id}/items",
+            f"{self.base_url_restx}/{shopcart.id}/items",
             json={},  # Empty request body
             content_type=DEFAULT_CONTENT_TYPE,
         )
@@ -283,14 +283,14 @@ class TestShopcartsService(BaseTestCase):
         item = ItemFactory()
 
         res = self.client.post(
-            f"{self.base_url}/{shopcart.id}/items",
+            f"{self.base_url_restx}/{shopcart.id}/items",
             json=item.serialize(),
             content_type="",
         )
         self.assertEqual(res.status_code, status.HTTP_415_UNSUPPORTED_MEDIA_TYPE)
 
         res = self.client.post(
-            f"{self.base_url}/{shopcart.id}/items",
+            f"{self.base_url_restx}/{shopcart.id}/items",
             json=item.serialize(),
             content_type="application/xml",
         )
@@ -306,7 +306,7 @@ class TestShopcartsService(BaseTestCase):
         mock_shopcart_update.side_effect = DataValidationError("Invalid data")
 
         res = self.client.post(
-            f"{self.base_url}/{shopcart.id}/items",
+            f"{self.base_url_restx}/{shopcart.id}/items",
             json=item.serialize(),
             content_type=DEFAULT_CONTENT_TYPE,
         )
@@ -318,13 +318,13 @@ class TestShopcartsService(BaseTestCase):
         shopcart = self._create_an_empty_shopcart(1)[0]
         item = ItemFactory(shopcart_id=shopcart.id)
         item.name = ""
-        resp = self.client.post(f"{self.base_url}/{shopcart.id}/items",
+        resp = self.client.post(f"{self.base_url_restx}/{shopcart.id}/items",
                                 json=item.serialize(),
                                 content_type=DEFAULT_CONTENT_TYPE)
         self.assertEqual(resp.status_code, status.HTTP_400_BAD_REQUEST)
 
         item.name = "  "
-        resp = self.client.post(f"{self.base_url}/{shopcart.id}/items",
+        resp = self.client.post(f"{self.base_url_restx}/{shopcart.id}/items",
                                 json=item.serialize(),
                                 content_type=DEFAULT_CONTENT_TYPE)
         self.assertEqual(resp.status_code, status.HTTP_400_BAD_REQUEST)
@@ -334,7 +334,7 @@ class TestShopcartsService(BaseTestCase):
         shopcart = self._create_an_empty_shopcart(1)[0]
         item = ItemFactory(shopcart_id=shopcart.id)
         item.name = None
-        resp = self.client.post(f"{self.base_url}/{shopcart.id}/items",
+        resp = self.client.post(f"{self.base_url_restx}/{shopcart.id}/items",
                                 json=item.serialize(),
                                 content_type=DEFAULT_CONTENT_TYPE)
         self.assertEqual(resp.status_code, status.HTTP_400_BAD_REQUEST)
@@ -344,19 +344,19 @@ class TestShopcartsService(BaseTestCase):
         shopcart = self._create_an_empty_shopcart(1)[0]
         item = ItemFactory(shopcart_id=shopcart.id)
         item.quantity = "Z"
-        resp = self.client.post(f"{self.base_url}/{shopcart.id}/items",
+        resp = self.client.post(f"{self.base_url_restx}/{shopcart.id}/items",
                                 json=item.serialize(),
                                 content_type=DEFAULT_CONTENT_TYPE)
         self.assertEqual(resp.status_code, status.HTTP_400_BAD_REQUEST)
 
         item.quantity = 1.2
-        resp = self.client.post(f"{self.base_url}/{shopcart.id}/items",
+        resp = self.client.post(f"{self.base_url_restx}/{shopcart.id}/items",
                                 json=item.serialize(),
                                 content_type=DEFAULT_CONTENT_TYPE)
         self.assertEqual(resp.status_code, status.HTTP_400_BAD_REQUEST)
 
         item.quantity = 2
-        resp = self.client.post(f"{self.base_url}/{shopcart.id}/items",
+        resp = self.client.post(f"{self.base_url_restx}/{shopcart.id}/items",
                                 json=item.serialize(),
                                 content_type=DEFAULT_CONTENT_TYPE)
         self.assertEqual(resp.status_code, status.HTTP_400_BAD_REQUEST)
@@ -366,13 +366,13 @@ class TestShopcartsService(BaseTestCase):
         shopcart = self._create_an_empty_shopcart(1)[0]
         item = ItemFactory(shopcart_id=shopcart.id)
         item.price = "Z"
-        resp = self.client.post(f"{self.base_url}/{shopcart.id}/items",
+        resp = self.client.post(f"{self.base_url_restx}/{shopcart.id}/items",
                                 json=item.serialize(),
                                 content_type=DEFAULT_CONTENT_TYPE)
         self.assertEqual(resp.status_code, status.HTTP_400_BAD_REQUEST)
 
         item.price = 100.0
-        resp = self.client.post(f"{self.base_url}/{shopcart.id}/items",
+        resp = self.client.post(f"{self.base_url_restx}/{shopcart.id}/items",
                                 json=item.serialize(),
                                 content_type=DEFAULT_CONTENT_TYPE)
         self.assertEqual(resp.status_code, status.HTTP_201_CREATED)


### PR DESCRIPTION
# Goal
Refactor Create Items API into Flask-RestX style while maintaining test coverage as before.

# Changes
1. Create ItemCollection class
2. Copy and refactor Create Items API implementation into ItemCollection class
3. Apply base_url_restx to all Create Items API test cases

# Results

## green
Note that the new missing lines in `routes.py` not covered in `test_routes.py` corresponds to the old API paths, which will later be removed in story #128.

![green](https://github.com/CSCI-GA-2820-SU23-001/shopcarts/assets/117547590/a1455238-c361-467e-bd6a-f6f67a31da5f)

## swagger doc
![create-items](https://github.com/CSCI-GA-2820-SU23-001/shopcarts/assets/117547590/90d35334-2a03-425f-9148-995dd04e7b30)
